### PR TITLE
Add GitHub Actions workflow for Tauri build

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -1,0 +1,25 @@
+name: Build Tauri App
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          TAURI_ACTION: build
+          TAURI_PROJECT_PATH: frontend
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add new `tauri-build.yml` workflow to compile Tauri app for each OS

## Testing
- `npx playwright test --reporter=list` *(fails: browser binaries missing)*