### PR TITLE
Fix vector property preview

### DIFF
--- a/frontend/src/components/skit/CommandList.tsx
+++ b/frontend/src/components/skit/CommandList.tsx
@@ -150,6 +150,17 @@ export const CommandList = memo(function CommandList() {
           case 'asset':
             newCommand[propName] = '';
             break;
+          case 'vector2':
+          case 'vector2Int':
+            newCommand[propName] = [0, 0];
+            break;
+          case 'vector3':
+          case 'vector3Int':
+            newCommand[propName] = [0, 0, 0];
+            break;
+          case 'vector4':
+            newCommand[propName] = [0, 0, 0, 0];
+            break;
         }
       }
     });


### PR DESCRIPTION
## Summary
- initialize vector property arrays when adding a command

## Testing
- `npm --prefix frontend run lint`
- `npx playwright test --reporter=list --project=chromium --max-workers=2 --timeout=0 --fail-on-load-error` *(fails: connect EHOSTUNREACH)*