### PR TITLE
Disable editor shortcuts during input editing

### DIFF
--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -15,6 +15,19 @@ export function useKeyboardShortcuts() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      const active = document.activeElement as HTMLElement | null;
+      const selection = window.getSelection();
+
+      if (
+        (active &&
+          (active.tagName === 'INPUT' ||
+            active.tagName === 'TEXTAREA' ||
+            active.isContentEditable)) ||
+        (selection && !selection.isCollapsed)
+      ) {
+        return;
+      }
+
       const key = event.key.toLowerCase();
       const meta = event.metaKey || event.ctrlKey;
 


### PR DESCRIPTION
## Summary
- disable keyboard shortcuts when a text input is focused or when text is selected

## Testing
- `npx playwright test --reporter=list` *(fails: browser executables missing)*