### PR TITLE
Fix drop index for collapsed groups

### DIFF
--- a/frontend/src/store/skitStore.ts
+++ b/frontend/src/store/skitStore.ts
@@ -777,6 +777,22 @@ export const getGroupCommandIndices = (commands: SkitCommand[], groupStartIndex:
   return indices;
 };
 
+export const findGroupStartIndex = (commands: SkitCommand[], groupEndIndex: number): number | null => {
+  let nestLevel = 0;
+  for (let i = groupEndIndex - 1; i >= 0; i--) {
+    const cmd = commands[i];
+    if (cmd.type === 'group_end') {
+      nestLevel++;
+    } else if (cmd.type === 'group_start') {
+      if (nestLevel === 0) {
+        return i;
+      }
+      nestLevel--;
+    }
+  }
+  return null;
+};
+
 export const getTopLevelGroups = (commands: SkitCommand[], selectedIndices: number[]): number[] => {
   return selectedIndices.filter(index => {
     const cmd = commands[index];


### PR DESCRIPTION
## Summary
- adjust reorder index when dropping onto a collapsed group's `group_end`
- expose helper to find the matching group start

## Testing
- `npx playwright test --reporter=list` *(fails: browsers not installed)*