### PR TITLE
Fix sample data loading for GitHub Pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
         const skits = await loadSkitsFiles(projectPath);
         loadSkits(skits);
       } catch (error) {
-        if (import.meta.env.DEV) {
+        if (import.meta.env.DEV || !('__TAURI__' in window)) {
           // 外部ファイルからサンプルデータをロード
           try {
             const sampleSkits = await loadSampleSkit();

--- a/frontend/src/utils/devFileSystem.ts
+++ b/frontend/src/utils/devFileSystem.ts
@@ -9,7 +9,8 @@ export async function loadSampleCommandsYaml(): Promise<string> {
     console.log('Loading commands.yaml for web environment');
     
     // Web環境でfetchを使用してファイルをロード
-    const response = await fetch('/src/sample/commands.yaml');
+    const url = `${import.meta.env.BASE_URL}src/sample/commands.yaml`;
+    const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`Failed to fetch commands.yaml: ${response.status}`);
     }
@@ -31,7 +32,8 @@ export async function loadSampleSkit(): Promise<Record<string, Skit>> {
     console.log('Loading sample-skit.json for web environment');
     
     // Web環境でfetchを使用してファイルをロード
-    const response = await fetch('/src/sample/skits/sample_skit.json');
+    const url = `${import.meta.env.BASE_URL}src/sample/skits/sample_skit.json`;
+    const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`Failed to fetch sample-skit.json: ${response.status}`);
     }


### PR DESCRIPTION
## Summary
- load sample data when the app runs on the web without Tauri
- build sample file URLs using `import.meta.env.BASE_URL`

## Testing
- `npm run build`
- `npx playwright test --reporter=list` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_b_683d5a56ffbc8333b2a13131a21458b1