### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  checks: write    # Vitest のレポーターが Checks にコメントする場合のみ
+
+defaults:
+  run:
+    working-directory: frontend   # 以降は ./frontend がカレント
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node: [20]         # 将来 22 に切り替えたい場合はここを増やす
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ---------- Node ----------
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      # ---------- Rust (Tauri) ----------
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri -> target
+
+      # ---------- Install / Lint / Test ----------
+      - run: npm ci
+      - run: npm run lint          # ESlint
+      - run: npm run typecheck     # tsc --noEmit
+      - run: npm run test          # Vitest
+      - run: npm run test:e2e --if-present  # Playwright（オプション）
+
+      # ---------- Build ----------
+      - run: npm run build         # Vite + Tailwind
+      # Rust 側のビルド（バイナリを生成するだけで署名/パッケージはしない）
+      - run: npm run tauri build -- --ci --bundles none

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- add CI workflow from user instructions
- add missing typecheck script for workflow

## Testing
- `npx playwright test --reporter=list` *(fails: browser not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683d2f8596048333b9ba2aa357e68a5f